### PR TITLE
Allow other TinyMCE plugins to register before

### DIFF
--- a/admin/class-aesop-core-admin.php
+++ b/admin/class-aesop-core-admin.php
@@ -161,9 +161,8 @@ class Aesop_Core_Admin {
 	 	*
 	 	* @since     1.1.0
 	*/
-	public function tinymce_plugin(){
+	public function tinymce_plugin($plugins_array){
 		$plugins = array('aiview','noneditable');
-		$plugins_array = array();
 
 		foreach ($plugins as $plugin) {
 			$plugins_array[ $plugin ] = plugins_url('assets/js/tinymce/', __FILE__) . $plugin . '/plugin.min.js';


### PR DESCRIPTION
The external plugins array is shared accross all plugins, so is nice to play fair and pass the ball, or in this case recieve the ball before passing it.

See: http://codex.wordpress.org/Plugin_API/Filter_Reference/mce_external_plugins#Creating_a_shortcode_and_a_tag_button

Regards