### PR TITLE
Changed image component markup

### DIFF
--- a/public/includes/components/component-image.php
+++ b/public/includes/components/component-image.php
@@ -50,8 +50,8 @@ if ( ! function_exists( 'aesop_image_shortcode' ) ) {
 
 			<?php do_action( 'aesop_image_inside_top', $atts, $unique ); // action ?>
 
-			<figure class="aesop-content">
-				<div class="aesop-image-component-image aesop-component-align-<?php echo sanitize_html_class( $atts['align'] );?> aesop-image-component-caption-<?php echo sanitize_html_class( $atts['captionposition'] );?>" <?php echo esc_attr( $offsetstyle );?>>
+			<div class="aesop-content">
+				<figure class="aesop-image-component-image aesop-component-align-<?php echo sanitize_html_class( $atts['align'] );?> aesop-image-component-caption-<?php echo sanitize_html_class( $atts['captionposition'] );?>" <?php echo esc_attr( $offsetstyle );?>>
 					<?php
 
 		do_action( 'aesop_image_inner_inside_top', $atts, $unique ); // action
@@ -86,8 +86,8 @@ if ( ! function_exists( 'aesop_image_shortcode' ) ) {
 
 					<?php do_action( 'aesop_image_inner_inside_bottom', $atts, $unique ); // action ?>
 
-				</div>
-			</figure>
+				</figure>
+			</div>
 
 			<?php do_action( 'aesop_image_inside_bottom', $atts, $unique ); // action ?>
 


### PR DESCRIPTION
Previous markup had figcaption element as a child inside a div, which is
invalid. (See http://www.w3.org/html/wg/drafts/html/master/single-page.html#the-figcaption-element for reference.)

For clarification, this is not a fix for the figure element, but rather for the figcaption. It is acceptable and semantic to have a div inside figure. It is not semantic, however, to have a figcaption element as a child in a div.